### PR TITLE
UI統一：ページスタイルを統一および開発ログイン実装

### DIFF
--- a/src/app/dev/logout/page.tsx
+++ b/src/app/dev/logout/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function DevLogout() {
+  const router = useRouter();
+  
+  useEffect(() => {
+    // Cookieからトークンを削除
+    document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    
+    // LocalStorageからもクリア
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    
+    // 少し待ってからログインページへリダイレクト
+    setTimeout(() => {
+      router.push('/po/login');
+    }, 1000);
+  }, [router]);
+  
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="bg-white p-8 rounded-lg shadow-md">
+        <h1 className="text-xl font-bold mb-4">開発用ログアウト</h1>
+        <p>ログアウト処理中...</p>
+        <p className="mt-4 text-sm text-gray-500">自動的にログインページにリダイレクトします</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -176,185 +176,195 @@ export default function Home() {
         <div className="flex justify-center flex-col lg:flex-row gap-6 w-full">
 
         {/* 検索フォーム全体をカードで囲む*/}
-        <div className="w-full lg:w-1/3 p-6 bg-white rounded-xl shadow-md space-y-4 mb-8">
-        <h1 className="text-base font-semibold text-gray-800 bg-blue-100 px-4 py-2 rounded-xl">スケジュール検索</h1>
-
-        {/* 検索フォーム */}
-        <div className="mb-4">
-          <label className="block mb-1 font-semibold">出港地：</label>
-            <select className="w-full p-2 border rounded" value={departure} onChange={(e) => setDeparture(e.target.value)}>
-            <option value="">選択してください</option>
-            {Object.keys(DEPARTURE_DESTINATION_MAP).map((port) => (
-              <option key={port} value={port}>{port}</option>
-            ))}
-          </select>
-        </div>
-
-        <div className="mb-4">
-          <label className="block mb-1 font-semibold">目的地：</label>
-          <select
-           className="w-full p-2 border rounded"
-            value={destination}
-            onChange={(e) => setDestination(e.target.value)}
-            disabled={!departure}
-          >
-           <option value="">選択してください</option>
-            {availableDestinations.map((port) => (
-              <option key={port} value={port}>{port}</option>
-            ))}
-          </select>
-        </div>
-
-        <div className="mb-4">
-          <label className="block mb-1 font-semibold">出港予定日（ETD）：</label>
-          <input
-           type="date"
-            className="w-full p-2 border rounded"
-            value={etd}
-            onChange={handleEtdChange}
-            disabled={eta !== ""}
-          />
-        </div>
-
-        <div className="mb-4">
-          <label className="block mb-1 font-semibold">到着予定日（ETA）：</label>
-          <input
-           type="date"
-            className="w-full p-2 border rounded"
-            value={eta}
-            onChange={handleEtaChange}
-            disabled={etd !== ""}
-          />
-        </div>
-
-        <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-          レコメンド取得
-        </button>
-
-        {isLoading && (
-          <div className="mt-4 text-blue-600 border border-blue-300 p-2 rounded bg-blue-50">
-            渡航スケジュールを確認中です...
+        <div className="w-full lg:w-1/3 bg-white rounded-md shadow-md mb-8 overflow-hidden">
+          <div className="bg-[#e6efff] px-4 py-3 flex justify-between items-center">
+            <h1 className="text-lg font-medium">スケジュール検索</h1>
           </div>
-        )}
-      </div>
-
-      {/* 結果表示 */}
-        <div className="w-full lg:w-2/3 px-6 bg-white rounded-xl shadow-md py-4 mb-8">
-        <h2 className="text-base font-semibold text-gray-800 bg-blue-100 px-4 py-2 rounded-xl">レコメンド</h2>
-
-        <div className="mt-4 space-y-4">
-          {results.length === 0 ? (
-          // レコメンド未取得時
-          <div className="border rounded p-4 bg-gray-50 text-gray-400">
-            レコメンド結果はまだありません。
-          </div>
-        ) : (
-         // レコメンド取得時
-          results.map((result, index) => (
-          <div key={index} className={`border rounded p-4 ${getStatusBgColor(result.status)} flex flex-col space-y-2`}>
-          {/* ステータスタグ */}
-          <div className="flex items-center justify-between mb-2">
-            {/* 船会社名とログインボタン（左寄せ） */}
-            <div className="flex items-center space-x-4">
-              <p className="text-xl font-bold">船会社：{result.company}</p>
-              <button className="bg-blue-600 text-white px-3 py-1 text-sm rounded">ログイン</button>
-            </div>
-            {/* ステータスボタン（右寄せ）*/}
-            <div className="space-x-2">
-              <button
-                onClick={() => handleStatusChange(index, "done")}
-                className={`px-3 py-1 rounded text-sm font-semibold 
-                  ${result.status === "done" ? "bg-blue-500 text-white" : "bg-blue-100 text-blue-600"}`}
-                >
-                手配済
-              </button>
-              <button
-                onClick={() => handleStatusChange(index, "processing")}
-                className={`px-3 py-1 rounded text-sm font-semibold 
-                  ${result.status === "processing" ? "bg-red-500 text-white" : "bg-pink-100 text-red-600"}`}
-              >       
-                手配中
-              </button>
-              <button
-                onClick={() => handleStatusChange(index, "exclude")}
-                className={`px-3 py-1 rounded text-sm font-semibold 
-                  ${result.status === "exclude" ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-700"}`}
-              >
-                除外
-              </button>
-            </div>
-          </div>
-
-          <hr className="border-t border-gray-300 mb-3" />
-
-          <div className="ml-4 space-y-1 mt-2 text-gray-800">
-            <p><strong>船名:</strong> {result.vessel}</p>
-            <p><strong>運賃:</strong> ${result.fare} </p>
-            <p><strong>出港日（ETD）:</strong> {result.etd}</p>
-            <p><strong>到着予定日（ETA）:</strong> {result.eta}</p>
-            <p>
-              <a
-                href={result.schedule_url ?? "#"} // ← fallbackを設定
-                className="text-blue-600 underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                スケジュールPDFを開く
-              </a>
-            </p>
-          </div>
-
           
-          <hr className="border-t border-gray-300 mb-3" />
+          <div className="p-6">
+            {/* 検索フォーム */}
+            <div className="mb-4">
+              <label className="block mb-1 font-semibold">出港地：</label>
+              <select className="w-full p-2 border rounded" value={departure} onChange={(e) => setDeparture(e.target.value)}>
+                <option value="">選択してください</option>
+                {Object.keys(DEPARTURE_DESTINATION_MAP).map((port) => (
+                  <option key={port} value={port}>{port}</option>
+                ))}
+              </select>
+            </div>
 
-          <div className="mt-4 flex justify-between items-center flex-wrap gap-2">
-           {/* 左側：質問＋Yes/Noボタン＋感謝メッセージ */}
-           <div className="flex items-center gap-2">
-            <span className="text-sm">この抽出内容は適切でしたか？</span>
+            <div className="mb-4">
+              <label className="block mb-1 font-semibold">目的地：</label>
+              <select
+                className="w-full p-2 border rounded"
+                value={destination}
+                onChange={(e) => setDestination(e.target.value)}
+                disabled={!departure}
+              >
+                <option value="">選択してください</option>
+                {availableDestinations.map((port) => (
+                  <option key={port} value={port}>{port}</option>
+                ))}
+              </select>
+            </div>
 
-            <button
-             onClick={() => handleFeedback(index, "yes")}
-              className={`px-3 py-1 rounded border text-sm font-semibold 
-                ${feedbackSentMap[index] === true ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-800 hover:bg-gray-300"}`}
-            >
-              Yes
+            <div className="mb-4">
+              <label className="block mb-1 font-semibold">出港予定日（ETD）：</label>
+              <input
+                type="date"
+                className="w-full p-2 border rounded"
+                value={etd}
+                onChange={handleEtdChange}
+                disabled={eta !== ""}
+              />
+            </div>
+
+            <div className="mb-4">
+              <label className="block mb-1 font-semibold">到着予定日（ETA）：</label>
+              <input
+                type="date"
+                className="w-full p-2 border rounded"
+                value={eta}
+                onChange={handleEtaChange}
+                disabled={etd !== ""}
+              />
+            </div>
+
+            <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+              レコメンド取得
             </button>
 
-            <button
-              onClick={() => handleFeedback(index, "no")}
-              className={`px-3 py-1 rounded border text-sm font-semibold 
-                ${feedbackSentMap[index] === false ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-800 hover:bg-gray-300"}`}
-            >
-             No
-            </button>
-
-           {feedbackSentMap[index] !== undefined && (
-             <span className="text-green-600 text-sm">フィードバックありがとうございます。</span>
+            {isLoading && (
+              <div className="mt-4 text-blue-600 border border-blue-300 p-2 rounded bg-blue-50">
+                渡航スケジュールを確認中です...
+              </div>
             )}
           </div>
+        </div>
 
-            {/* ChatGPT抽出内容表示 */}
-              <button onClick={() => toggleRaw(index)} className="text-sm text-blue-600 underline">
-                {showRawMap[index] ? "ChatGPTの抽出内容を隠す" : "ChatGPTの抽出内容を表示"}
-              </button>
-                {showRawMap[index] && (
-              <textarea className="w-full h-32 p-2 border rounded mt-2 bg-white" value={result.raw_response} readOnly></textarea>
-                )}
+      {/* 結果表示 */}
+        <div className="w-full lg:w-2/3 bg-white rounded-md shadow-md mb-8 overflow-hidden">
+          {/* ヘッダー部分 - PO読取画面のスタイルに合わせる */}
+          <div className="bg-[#e6efff] px-4 py-3 flex justify-between items-center">
+            <h2 className="text-lg font-medium">レコメンド</h2>
+          </div>
+
+          {/* コンテンツ部分 - パディングを適用 */}
+          <div className="px-6 py-4">
+            {/* 結果リスト */}
+            <div className="mt-4 space-y-4">
+              {results.length === 0 ? (
+                // レコメンド未取得時
+                <div className="border rounded p-4 bg-gray-50 text-gray-400">
+                  レコメンド結果はまだありません。
+               </div>
+             ) : (
+                // レコメンド取得時
+                results.map((result, index) => (
+                 <div key={index} className={`border rounded p-4 ${getStatusBgColor(result.status)} flex flex-col space-y-2`}>
+                  {/* ステータスタグ */}
+                  <div className="flex items-center justify-between mb-2">
+                    {/* 船会社名とログインボタン（左寄せ） */}
+                    <div className="flex items-center space-x-4">
+                    <p className="text-xl font-bold">船会社：{result.company}</p>
+                    <button className="bg-blue-600 text-white px-3 py-1 text-sm rounded">ログイン</button>
+                  </div>
+                    {/* ステータスボタン（右寄せ）*/}
+                    <div className="space-x-2">
+                      <button
+                       onClick={() => handleStatusChange(index, "done")}
+                       className={`px-3 py-1 rounded text-sm font-semibold 
+                         ${result.status === "done" ? "bg-blue-500 text-white" : "bg-blue-100 text-blue-600"}`}
+                      >
+                        ＢＫＧ済
+                      </button>
+                      <button
+                        onClick={() => handleStatusChange(index, "processing")}
+                        className={`px-3 py-1 rounded text-sm font-semibold 
+                         ${result.status === "processing" ? "bg-red-500 text-white" : "bg-pink-100 text-red-600"}`}
+                      >       
+                        ＢＫＧ中
+                      </button>
+                      <button
+                        onClick={() => handleStatusChange(index, "exclude")}
+                        className={`px-3 py-1 rounded text-sm font-semibold 
+                          ${result.status === "exclude" ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-700"}`}
+                      >
+                        除外
+                      </button>
+                    </div>
+                  </div>
+
+                  <hr className="border-t border-gray-300 mb-3" />
+
+                  <div className="ml-4 space-y-1 mt-2 text-gray-800">
+                    <p><strong>船名:</strong> {result.vessel}</p>
+                    <p><strong>運賃:</strong> ${result.fare} </p>
+                    <p><strong>出港日（ETD）:</strong> {result.etd}</p>
+                    <p><strong>到着予定日（ETA）:</strong> {result.eta}</p>
+                    <p>
+                      <a
+                        href={result.schedule_url ?? "#"} // ← fallbackを設定
+                        className="text-blue-600 underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        スケジュールPDFを開く
+                      </a>
+                    </p>
+                  </div>
+
+          
+                  <hr className="border-t border-gray-300 mb-3" />
+
+                  <div className="mt-4 flex justify-between items-center flex-wrap gap-2">
+                    {/* 左側：質問＋Yes/Noボタン＋感謝メッセージ */}
+                      <div className="flex items-center gap-2">
+                      <span className="text-sm">この抽出内容は適切でしたか？</span>
+
+                      <button
+                        onClick={() => handleFeedback(index, "yes")}
+                        className={`px-3 py-1 rounded border text-sm font-semibold 
+                          ${feedbackSentMap[index] === true ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-800 hover:bg-gray-300"}`}
+                      >
+                        Yes
+                      </button>
+
+                      <button
+                        onClick={() => handleFeedback(index, "no")}
+                        className={`px-3 py-1 rounded border text-sm font-semibold 
+                          ${feedbackSentMap[index] === false ? "bg-gray-500 text-white" : "bg-gray-200 text-gray-800 hover:bg-gray-300"}`}
+                      >
+                        No
+                      </button>
+
+                      {feedbackSentMap[index] !== undefined && (
+                        <span className="text-green-600 text-sm">フィードバックありがとうございます。</span>
+                        )}
+                  </div>
+
+                  {/* ChatGPT抽出内容表示 */}
+                  <button onClick={() => toggleRaw(index)} className="text-sm text-blue-600 underline">
+                    {showRawMap[index] ? "ChatGPTの抽出内容を隠す" : "ChatGPTの抽出内容を表示"}
+                  </button>
+                    {showRawMap[index] && (
+                      <textarea className="w-full h-32 p-2 border rounded mt-2 bg-white" value={result.raw_response} readOnly></textarea>
+                    )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+           {/* エラーメッセージ（共通） */}
+            {(submitted && !isLoading && (error || results.length === 0)) && (
+              <div className="mt-4 text-red-600 border border-red-300 p-2 rounded bg-red-50">
+                {error || "該当する船便がありませんでした。"}
+              </div>
+            )}
+            </div>
           </div>
         </div>
-      ))
-    )}
-  </div>
-
-  {/* エラーメッセージ（共通） */}
-  {(submitted && !isLoading && (error || results.length === 0)) && (
-    <div className="mt-4 text-red-600 border border-red-300 p-2 rounded bg-red-50">
-      {error || "該当する船便がありませんでした。"}
-    </div>
-  )}
-  </div>
-    </div>
-
   </div> 
 
   <Script

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react'; // <-- useState を追加
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 const Navbar = () => {
   const pathname = usePathname();
+  
+  // <-- 以下を追加: 開発メニューの表示状態とチェックを行う変数 -->
+  const [showDevMenu, setShowDevMenu] = useState(false);
+  const isDevelopment = process.env.NODE_ENV === 'development';
 
   // パスに基づいてアクティブなリンクを判断する関数
   const isActive = (path: string) => {
@@ -18,36 +22,70 @@ const Navbar = () => {
       <nav className="flex">
         <Link
           href="/po/upload"
-          className={`px-6 h-[60px] text-[18px] hover:bg-white/10 transition flex items-center ${
-            isActive('/po/read') ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' : ''
+          className={`px-6 h-[60px] text-[18px] transition flex items-center ${
+            isActive('/po/upload') 
+              ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' 
+              : 'hover:bg-white/10'
           }`}
         >
           PO読取
         </Link>
         <Link
           href="/po/list"
-          className={`px-6 h-[60px] text-[18px] hover:bg-white/10 transition flex items-center ${
-            isActive('/po/list') ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' : ''
+          className={`px-6 h-[60px] text-[18px] transition flex items-center ${
+            isActive('/po/list') 
+              ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' 
+              : 'hover:bg-white/10'
           }`}
         >
           一覧
         </Link>
         <Link
           href="/"
-          className={`px-6 h-[60px] text-[18px] hover:bg-white/10 transition flex items-center ${
-            isActive('/') ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' : ''
+          className={`px-6 h-[60px] text-[18px] transition flex items-center ${
+            isActive('/') && !isActive('/po') && !isActive('/forecast') 
+              ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' 
+              : 'hover:bg-white/10'
           }`}
         >
           船ブッキング
         </Link>
         <Link
           href="/forecast"
-          className={`px-6 h-[60px] text-[18px] hover:bg-white/10 transition flex items-center ${
-            isActive('/forecast') ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' : ''
+          className={`px-6 h-[60px] text-[18px] transition flex items-center ${
+            isActive('/forecast') 
+              ? 'bg-[#dce8ff] text-[rgba(0,0,0,0.8)] font-medium' 
+              : 'hover:bg-white/10'
           }`}
         >
           バンニング見込み
         </Link>
+        
+        {/* <-- ここから追加: 開発環境でのみ表示する開発メニュー --> */}
+        {isDevelopment && (
+          <div className="relative ml-4">
+            <button 
+              className="px-4 h-[60px] text-[16px] bg-amber-500 text-white flex items-center"
+              onClick={() => setShowDevMenu(!showDevMenu)}
+            >
+              開発環境
+            </button>
+            
+            {showDevMenu && (
+              <div className="absolute top-[60px] right-0 bg-white text-gray-800 shadow-lg rounded-b-md w-48 z-50">
+                <Link 
+                  href="/dev/logout" 
+                  className="block px-4 py-2 hover:bg-gray-100"
+                >
+                  ログアウト
+                </Link>
+                
+              </div>
+            )}
+          </div>
+        )}
+        {/* <-- ここまで追加 --> */}
+        
       </nav>
     </header>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,56 @@
+// middleware.ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // 開発環境かどうかを確認
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  
+  // 開発環境の場合は自動ログイントークンを設定
+  if (isDevelopment) {
+    // 既存のトークンがなければ自動ログイン用のトークンを設定
+    const token = request.cookies.get('token')?.value;
+    if (!token) {
+      // 次のレスポンスに自動ログイン用のトークンを設定
+      const response = NextResponse.next();
+      response.cookies.set('token', 'dev-auto-login-token', { 
+        path: '/',
+        maxAge: 86400 // 24時間
+      });
+      return response;
+    }
+  }
+
+  // 以下は既存のコード
+  // トークンがあるかチェック
+  const token = request.cookies.get('token')?.value || '';
+  
+  // ログインページへのアクセスかどうか
+  const isLoginPage = request.nextUrl.pathname === '/po/login';
+  
+  // ログイン不要なパスの配列
+  const publicPaths = ['/po/login'];
+  const isPublicPath = publicPaths.includes(request.nextUrl.pathname);
+  
+  // ログインしていない場合かつ保護されたパスへアクセスしようとしている場合
+  if (!token && !isPublicPath) {
+    // ログインページにリダイレクト
+    const loginUrl = new URL('/po/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+  
+  // ログイン済みでログインページにアクセスしようとした場合
+  if (token && isLoginPage) {
+    // ホームページにリダイレクト
+    const homeUrl = new URL('/', request.url);
+    return NextResponse.redirect(homeUrl);
+  }
+  
+  // それ以外の場合は通常通り進める
+  return NextResponse.next();
+}
+
+// 特定のパスにのみミドルウェアを適用する設定
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
〈修正内容〉
・ナビゲーションバーのアクティブ選択部分にカーソルを乗せでも色が反転しないよう修正。
・トークンがない状態でナビゲーションバーを選択するとログイン画面に遷移するように修正、開発用ログイン・ログアウト機能追加（もしデプロイ環境に響き、不要でしたら削除します。コード内に追加部分としてコメント記載しています）
※開発用でログインすると、ナビゲーションバーに「開発環境」と出るようにしています。
・レコメンドカードのステータスを「BKG中」「BKG済」「除外」に修正。
・船ブッキング画面の「スケジュール検索」「レコメンド」項目部分の色味および形状をPO画面と統一。